### PR TITLE
Add GALA to G section

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,8 +435,9 @@ FAST programs are written as plain text and then sent thru the FAST compiler. Sm
 - [Fuzion](https://github.com/tokiwa-software/fuzion) - A language with a focus on safety and performance. It unifies concepts found in other programming languages to improve productivity and shall provide tools for performance and correctness.
 - [Fuzuli](http://stdioe.blogspot.com/search/label/fuzuli) - JFuzuli is the JVM implementation of our programming language Fuzuli which is based on LISP syntax and Algol family programming logic. Fuzuli is a modern collaboration of these two separate family of languages.
 <a name="G"></a>
-# G (46):
+# G (47):
 - [G](https://github.com/pouyathe/glang) - A fast, easy syntex, tiny footprint (about 2.4MB) and script language.
+- [GALA](https://github.com/martianoff/gala) - GALA (Go Alternative Language) is a functional programming language that transpiles to Go, adding sealed types, exhaustive pattern matching, immutability by default, monads (Option, Either, Try, Future), and immutable collections. [functional, transpiler, go, pattern-matching]
 - [GALATEA](https://galatea.sourceforge.net/Home.htm) - Glider with Autonomous, Logic-based Agents, TEmporal reasoning and Abduction. GALATEA is software to model and simulate multi-agent systems. It is the product of two lines of research: simulation languages based on Zeigler's theory of simulation and logic-based agents. There is, in GALATEA, a proposal to integrate, in the same simulation platform, conceptual and concrete tools for multi-agent, distributed, interactive, continuous and discrete event simulation. 
 - [Gambas](https://gambas.sourceforge.net/en/main.html) - Gambas is a full-featured object language and development environment built on a BASIC interpreter.
 - [GameMonkey Script](https://github.com/publicrepo/gmscript) - Embedded scripting language for C++ apps, tools and games.


### PR DESCRIPTION
Add [GALA](https://github.com/martianoff/gala) to the G section and update count from 46 to 47.

GALA (Go Alternative Language) is a functional programming language that transpiles to Go. It adds sealed types, exhaustive pattern matching, immutability by default, monads (Option, Either, Try, Future), and immutable collections to the Go ecosystem.

- Apache 2.0 licensed
- Pre-built binaries for Linux, macOS, and Windows
- [Online playground](https://gala-playground.fly.dev)