### PR TITLE
Add Nudge - typed programming language for LLM agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -873,6 +873,7 @@ of the code.
 <a name="N"></a>
 # N (30):
 - [NAAb](https://github.com/b-macker/NAAb) - NAAb is a polyglot programming language that integrates Python, JavaScript, Rust, C++, Go, C#, Ruby, PHP, Shell, Nim, Zig, and Julia through an innovative block system. Write the best language for each task in a single file with automatic variable flow between languages. Features a built-in LLM governance engine with 50+ checks, 12 stdlib modules, lambda expressions, pattern matching, and a recursive descent parser built on 15,000+ lines of C++17. [AI]
+- [Nudge](https://github.com/NekomyaDev/nudge) - A typed, replayable, budget-aware programming language for LLM agents. Compiles to Python & TypeScript. Features typed LLM calls with schema validation, deterministic replay, budget contracts, effect system, and native parallelism.
 - [Nasal](https://web.archive.org/web/20140626001245/http://www.plausible.org/nasal/) - Nasal: Not another scripting language!
   - Vectors, Hashes and Scalars (number/strings)
   - "Normal" OOP syntax


### PR DESCRIPTION
## What

Added [Nudge](https://github.com/NekomyaDev/nudge) to the N section.

## Why

Nudge is a typed, replayable, budget-aware programming language for LLM agents:

- **Typed LLM calls** — output schema is a language type; violations trigger automatic repair
- **Deterministic replay** — every run emits a trace; every trace is a test
- **Budget contracts** — per-call, per-run USD ceilings enforced by compiler + runtime
- **Effect system** — pure / LLM / Tool / IO effects inferred and shown in signatures
- **Native parallelism** — `par map`, `par race`, `par all` with compile-time race safety
- **Compiles to Python & TypeScript**
- **Zero dependencies** — single Rust binary, builds in seconds

## Links

- GitHub: https://github.com/NekomyaDev/nudge
- VS Code Extension: https://marketplace.visualstudio.com/items?itemName=Nekomya.nudge-lang